### PR TITLE
Make it possible to extend RequestHandler

### DIFF
--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -16,12 +16,12 @@ class RequestHandler implements MiddlewareInterface
     /**
      * @var ContainerInterface Used to resolve the handlers
      */
-    private $container;
+    protected $container;
 
     /**
      * @var string Attribute name for handler reference
      */
-    private $handlerAttribute = 'request-handler';
+    protected $handlerAttribute = 'request-handler';
 
     /**
      * Set the resolver instance.


### PR DESCRIPTION
Hey, I wanted to extend RequestHandler but wasn't able to access `$this->container` or `$this->handlerAttribute` because they're private. This PR degrades the properties to protected so that we can access them if we need to.