### PR TITLE
Support psr/container 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.2 || ^8.0",
         "middlewares/utils": "^3.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0||^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8|^9",
@@ -31,9 +31,6 @@
         "squizlabs/php_codesniffer": "^3.0",
         "phpstan/phpstan": "^0.12",
         "laminas/laminas-diactoros": "^2.3"
-    },
-    "suggest": {
-        "psr/container": "Can be used to resolve handlers automatically"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi, this adds support for psr/container ^2.0. It merely adds a return type to one of the `ContainerInterface` methods, so there is no breaking change for this package. Also, since psr/container is a hard dependency now, I've removed it from `suggest` where it seems redundant.