### PR TITLE
Allow psr/http-message 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "middlewares/utils": "^3.0",
+        "middlewares/utils": "^3.0 || ^4.0",
         "psr/http-server-middleware": "^1.0",
         "psr/container": "^1.0||^2.0"
     },
@@ -30,7 +30,7 @@
         "oscarotero/php-cs-fixer-config": "^1.0",
         "squizlabs/php_codesniffer": "^3.0",
         "phpstan/phpstan": "^0.12",
-        "laminas/laminas-diactoros": "^2.3"
+        "laminas/laminas-diactoros": "^2.3 || ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The low version for `middlewares/utils` and `laminas/laminas-diactoros` cause a conflict with  `psr/http-message:2.0`